### PR TITLE
add ci integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,20 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "@types/node": "14.x",
+        "@types/rewire": "^2.5.30",
+        "@types/sinon": "^17.0.4",
         "@types/vscode": "^1.54.0",
         "@typescript-eslint/eslint-plugin": "^8.33.0",
         "@vscode/test-electron": "^2.5.2",
         "eslint": "^9.28.0",
         "glob": "^7.1.7",
         "mocha": "^8.4.0",
+        "rewire": "^7.0.0",
+        "sinon": "^20.0.0",
         "typescript": "^4.3.2"
       },
       "engines": {
-        "vscode": "^1.54.0"
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -252,6 +256,35 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -265,6 +298,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
@@ -316,6 +357,48 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -436,6 +519,30 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
       "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
       "dev": true
+    },
+    "node_modules/@types/rewire": {
+      "version": "2.5.30",
+      "resolved": "https://registry.npmjs.org/@types/rewire/-/rewire-2.5.30.tgz",
+      "integrity": "sha512-CSyzr7TF1EUm85as2noToMtLaBBN/rKKlo5ZDdXedQ64cUiHT25LCNo1J1cI4QghBlGmTymElW/2h3TiWYOsZw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.57.0",
@@ -809,6 +916,13 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
@@ -939,10 +1053,11 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1213,6 +1328,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -1851,6 +1979,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -1980,6 +2118,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2571,6 +2717,264 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rewire": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-7.0.0.tgz",
+      "integrity": "sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint": "^8.47.0"
+      }
+    },
+    "node_modules/rewire/node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/rewire/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/rewire/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rewire/node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/rewire/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/rewire/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/rewire/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/rewire/node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/rewire/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/rewire/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rewire/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rewire/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/rewire/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2679,6 +3083,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sinon": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
@@ -2722,12 +3154,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -2756,6 +3189,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2794,6 +3234,29 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3144,10 +3607,38 @@
         }
       }
     },
+    "@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
     "@humanwhocodes/retry": {
@@ -3180,6 +3671,43 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+          "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+          "dev": true
+        }
       }
     },
     "@stylistic/eslint-plugin": {
@@ -3266,6 +3794,27 @@
       "version": "14.17.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
       "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==",
+      "dev": true
+    },
+    "@types/rewire": {
+      "version": "2.5.30",
+      "resolved": "https://registry.npmjs.org/@types/rewire/-/rewire-2.5.30.tgz",
+      "integrity": "sha512-CSyzr7TF1EUm85as2noToMtLaBBN/rKKlo5ZDdXedQ64cUiHT25LCNo1J1cI4QghBlGmTymElW/2h3TiWYOsZw==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
     "@types/vscode": {
@@ -3493,6 +4042,12 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true
+    },
     "@vscode/test-electron": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
@@ -3581,9 +4136,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -3776,6 +4331,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -4204,6 +4768,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -4303,6 +4873,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -4704,6 +5280,184 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true
     },
+    "rewire": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-7.0.0.tgz",
+      "integrity": "sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^8.47.0"
+      },
+      "dependencies": {
+        "@eslint/eslintrc": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+          "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.12.4",
+            "debug": "^4.3.2",
+            "espree": "^9.6.0",
+            "globals": "^13.19.0",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^4.1.0",
+            "minimatch": "^3.1.2",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "@eslint/js": {
+          "version": "8.57.1",
+          "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+          "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "eslint": {
+          "version": "8.57.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+          "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.2.0",
+            "@eslint-community/regexpp": "^4.6.1",
+            "@eslint/eslintrc": "^2.1.4",
+            "@eslint/js": "8.57.1",
+            "@humanwhocodes/config-array": "^0.13.0",
+            "@humanwhocodes/module-importer": "^1.0.1",
+            "@nodelib/fs.walk": "^1.2.8",
+            "@ungap/structured-clone": "^1.2.0",
+            "ajv": "^6.12.4",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
+            "debug": "^4.3.2",
+            "doctrine": "^3.0.0",
+            "escape-string-regexp": "^4.0.0",
+            "eslint-scope": "^7.2.2",
+            "eslint-visitor-keys": "^3.4.3",
+            "espree": "^9.6.1",
+            "esquery": "^1.4.2",
+            "esutils": "^2.0.2",
+            "fast-deep-equal": "^3.1.3",
+            "file-entry-cache": "^6.0.1",
+            "find-up": "^5.0.0",
+            "glob-parent": "^6.0.2",
+            "globals": "^13.19.0",
+            "graphemer": "^1.4.0",
+            "ignore": "^5.2.0",
+            "imurmurhash": "^0.1.4",
+            "is-glob": "^4.0.0",
+            "is-path-inside": "^3.0.3",
+            "js-yaml": "^4.1.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.4.1",
+            "lodash.merge": "^4.6.2",
+            "minimatch": "^3.1.2",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.9.3",
+            "strip-ansi": "^6.0.1",
+            "text-table": "^0.2.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "7.2.2",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+          "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "espree": {
+          "version": "9.6.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+          "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.9.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+          "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "flat-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+          "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+          "dev": true,
+          "requires": {
+            "flatted": "^3.2.9",
+            "keyv": "^4.5.3",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "ignore": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+          "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4761,6 +5515,27 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true
     },
+    "sinon": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+          "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+          "dev": true
+        }
+      }
+    },
     "stdin-discarder": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
@@ -4796,12 +5571,12 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-json-comments": {
@@ -4818,6 +5593,12 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -4843,6 +5624,18 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "icon": "Logo.png",
   "engines": {
-    "vscode": "^1.54.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -81,15 +81,19 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "^4.4.0",
     "@stylistic/eslint-plugin-ts": "^4.4.0",
-    "@typescript-eslint/eslint-plugin": "^8.33.0",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "14.x",
+    "@types/rewire": "^2.5.30",
+    "@types/sinon": "^17.0.4",
     "@types/vscode": "^1.54.0",
+    "@typescript-eslint/eslint-plugin": "^8.33.0",
     "@vscode/test-electron": "^2.5.2",
     "eslint": "^9.28.0",
     "glob": "^7.1.7",
     "mocha": "^8.4.0",
+    "rewire": "^7.0.0",
+    "sinon": "^20.0.0",
     "typescript": "^4.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   ],
   "activationEvents": [
     "onCommand:acpihelper.HelpInfo",
-    "onLanguage:EASL"
+    "onLanguage:EASL",
+    "onCommand:acpihelper.reloadConfig"
   ],
   "capabilities": {
     "hoverProvider": "true"
@@ -27,7 +28,14 @@
     "commands": [
       {
         "command": "acpihelper.HelpInfo",
-        "title": "Help"
+        "title": "Help",
+        "category": "ACPI Helper"
+      },
+      {
+        "command": "acpihelper.reloadConfig",
+        "title": "Reload Config",
+        "shortTitle": "Reload",
+        "category": "ACPI Helper"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -71,8 +71,10 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
+    "compile-test": "tsc -p ./ && npm run copy-test-fixtures",
+    "copy-test-fixtures": "cp -r src/test/fixtures out/test/",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile-test && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,21 +5,7 @@ import * as vscode from 'vscode';
 import { ConfigManager } from './lib/configmanager';
 
 export const configManager = new ConfigManager("");
-// let ExtConfigKey: string[]=['ORIG'];
-// let ExtConfigDesc: string[]=['Original arrays'];
 let output: vscode.OutputChannel;
-
-
-// Export the arrays for testing
-// export { ExtConfigDesc, ExtConfigKey };
-
-// Export global arrays getter function when in test environment
-// export function getTestConfig() {
-    // if (process.env.NODE_ENV == 'test') {
-        // return { ExtConfigKey, ExtConfigDesc };
-    // }
-    // return undefined;
-// }
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -123,35 +109,10 @@ function loadConfig(context: vscode.ExtensionContext) {
 
 		configManager.configPath = cfgPath;
 
-		// vscode.workspace.openTextDocument(cfgPath).then(document => {
-		// 	let AcpiCfgStr = document.getText();
-		// 	output.appendLine('Parse Ext ACPI Cfg File!');
-		// 	let ParsedResult = JSON.parse(AcpiCfgStr);
-		// 	let KeyNum = Object.keys(ParsedResult).length;
-		// 	// TODO: Remove debugging
-        //     // Log before pushing
-        //     output.appendLine('Before pushing - ExtConfigKey:' + ExtConfigKey);
-		// 	output.appendLine('Before pushing - ExtConfigDesc:' + ExtConfigDesc);
-
-		// 	output.appendLine(KeyNum.toString());
-		// 	for (var i = 0; i < KeyNum; i++) {
-		// 		ExtConfigKey.push(ParsedResult[i].KeyWord);
-		// 		ExtConfigDesc.push(ParsedResult[i].Desc);
-		// 		output.appendLine(ParsedResult[i].KeyWord);
-		// 		output.appendLine(ParsedResult[i].Desc);
-		// 	}
-
-		// 	// TODO: Remove debugging
-        //     // Log after pushing
-        //     output.appendLine('After pushing - ExtConfigKey:' + ExtConfigKey);
-        //     output.appendLine('After pushing - ExtConfigDesc:' + ExtConfigDesc);
-		// })
 		configManager.loadConfig(output).then(() => {
 			output.appendLine('Finished loading config!');
             // TODO: Remove debugging
 			// Log final state
-            // output.appendLine('Final state - ExtConfigKey:' + ExtConfigKey);
-			// output.appendLine('Final state - ExtConfigDesc:' + ExtConfigDesc);
 			output.appendLine('loadConfig(): Final state - configManager.configKey:' + configManager.configKey);
 			output.appendLine('loadConfig(): Final state - configManager.configDesc:' + configManager.configDesc);
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,12 @@ export function activate(context: vscode.ExtensionContext) {
 		// Display a message box to the user
 		vscode.window.showInformationMessage('Hello World from AcpiHelper!');
 	});
-  
+
+    // Add reload config command
+    let reloadConfig = vscode.commands.registerCommand('acpihelper.reloadConfig', () => {
+        loadConfig(context);
+        return Promise.resolve();
+    });
 	 
 
 	vscode.languages.registerHoverProvider('EASL', {
@@ -53,6 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   
 	context.subscriptions.push(disposable);
+	context.subscriptions.push(reloadConfig);
 }
 
 // Load or reload the extension config

--- a/src/lib/configmanager.ts
+++ b/src/lib/configmanager.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+
+class ConfigManager {
+    private _configPath: string;
+    private _configKey: string[] = [];
+    private _configDesc: string[] = [];
+
+    constructor(path: string) {
+        this._configPath = path;
+    }
+
+    set configPath(path: string) {
+        this._configPath = path;
+    }
+
+    get configKey(): string[] {
+        return [...this._configKey];
+    }
+
+    get configDesc(): string[] {
+        return [...this._configDesc];
+    }
+
+    resetConfig() {
+        this._configKey = [];
+        this._configDesc = [];
+    }
+
+    push(key: string, desc: string) {
+        this._configKey.push(key);
+        this._configDesc.push(desc);
+    }
+
+    loadConfig(output?: vscode.OutputChannel | vscode.LogOutputChannel): Promise<void> | PromiseLike<void> {
+        return vscode.workspace.openTextDocument(this._configPath)
+            .then((document) => {
+                if (output) {
+                    output.appendLine('Initial array state - this._configKey:' + this._configKey);
+                    output.appendLine('Initial array state - this._configDesc:' + this._configDesc);
+                    output.appendLine('Parse Ext ACPI Cfg File!');
+                }
+                const config = JSON.parse(document.getText());
+                this.resetConfig();
+                for (const item of config) {
+                    if (output) {
+                        output.appendLine('Before pushing - this._configKey:' + this._configKey);
+                        output.appendLine('Before pushing - this._configDesc:' + this._configDesc);
+                    }
+                    this.push(item.KeyWord, item.Desc);
+                    if (output) {
+                        output.appendLine(item.KeyWord);
+                        output.appendLine(item.Desc);
+                    }
+                }
+                if (output) {
+                    output.appendLine('Final state - this._configKey:' + this._configKey);
+                    output.appendLine('Final state - this._configDesc:' + this._configDesc);
+                }
+            });
+    }
+}
+
+// Export the class
+export { ConfigManager };

--- a/src/test/fixtures/AcpiCfg-test.json
+++ b/src/test/fixtures/AcpiCfg-test.json
@@ -1,0 +1,26 @@
+[
+  {
+    "KeyWord": "CUST",
+    "Desc": "CUSTOM Keyword Test"
+  },
+  {
+    "KeyWord": "ECRD",
+    "Desc": "EC Read"
+  },
+  {
+    "KeyWord": "ALSD",
+    "Desc": "ALS Sensors Device"
+  },
+  {
+    "KeyWord": "WFRK",
+    "Desc": "WIFI RF Kill Pin Set"
+  },
+  {
+    "KeyWord": "BTRK",
+    "Desc": "BT RF Kill Pin Set"
+  },
+  {
+    "KeyWord": "GBTR",
+    "Desc": "Get BT RF Kill Pin Value"
+  }
+]

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -12,10 +12,23 @@ async function main() {
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
+		console.log('Starting tests...');
+		console.log('Extension path:', extensionDevelopmentPath);
+		console.log('Test path:', extensionTestsPath);
+
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({
+			extensionDevelopmentPath, extensionTestsPath,
+			// launchArgs: ['--disable-extensions'],
+			// launchArgs: ['--enable-proposed-api nativeWindowHandle'],
+			extensionTestsEnv: {
+				VSCODE_DEBUG_MODE: 'true',
+				VSCODE_EXTENSION_TESTS: 'true'
+			}
+		 });
 	} catch (err) {
 		console.error('Failed to run tests');
+		console.error('Test run failed with error:', err);
 		process.exit(1);
 	}
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -21,10 +21,10 @@ async function main() {
 			extensionDevelopmentPath, extensionTestsPath,
 			// launchArgs: ['--disable-extensions'],
 			// launchArgs: ['--enable-proposed-api nativeWindowHandle'],
-			extensionTestsEnv: {
-				VSCODE_DEBUG_MODE: 'true',
-				VSCODE_EXTENSION_TESTS: 'true'
-			}
+			// extensionTestsEnv: {
+			// 	VSCODE_DEBUG_MODE: 'true',
+			// 	VSCODE_EXTENSION_TESTS: 'true'
+			// }
 		 });
 	} catch (err) {
 		console.error('Failed to run tests');

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -9,14 +9,9 @@ import { ConfigManager } from '../../lib/configmanager';
 import rewire = require("rewire");
 let acpihelper = rewire("../../extension");
 
-// const getTestConfig = acpihelper.getTestConfig;
-// if (!getTestConfig) {
-//     throw new Error('Test config not available');
-// }
 let mockOutputChannel: sinon.SinonStubbedInstance<vscode.OutputChannel>;
 let mockLogOutputChannel: sinon.SinonStubbedInstance<vscode.LogOutputChannel>;
 
-// const { ExtConfigKey, ExtConfigDesc } = config;
 suite('Extension Test Suite', function (this: Mocha.Suite) {
 	// TODO: Remove Debug timeout
 	this.timeout(30000);
@@ -24,25 +19,15 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
     // let outputChannel: vscode.OutputChannel;
 	let testOutput: string[] = [];
 	let sandbox: sinon.SinonSandbox;
-	// let configSpy: sinon.SinonSpy;
-	
-	let extensionConfigManager: ConfigManager;
-	// let ExtConfigKey: string[] = ['FOO'];
-	// let ExtConfigDesc: string[] = ['Will it Foo?'];
+	let configManager: ConfigManager;
 
 	suiteSetup(() => {
 		console.log('Setting up test suite...');
 		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
 		console.log('Before rewire: Is extension active:', extension?.isActive);
-		// extensionConfigManager = extension?.exports.__get__('configManager');
+		configManager = extension?.exports.__get__('configManager');
 
 		// Log the initial state of the arrays in the extension
-		// console.log('Initial extension arrays:', {
-		// 	ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
-		// 	ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
-		// });
-		// let configManager = acpihelper.__get__('configManager');
-		let configManager = acpihelper.configManager;
 		console.log('Initial extension arrays:', {
 			configKey: configManager.configKey,
 			configDesc: configManager.configDesc,
@@ -50,22 +35,7 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 			// "extensionConfigManager.configDesc": extensionConfigManager.configDesc
 		});
 
-		// Rewire the global external config arrays with our own
-		// acpihelper.__set__({
-			// ExtConfigKey: ExtConfigKey,
-			// ExtConfigDesc: ExtConfigDesc
-		// });
-
-		// Log the state after rewiring
-		// console.log('Arrays after rewiring:', {
-		// 	ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
-		// 	ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
-		// });
-		// console.log('After rewire: Is extension active:', extension?.isActive);
-
 		sandbox = sinon.createSandbox();
-
-		// configSpy = sandbox.spy(acpihelper, 'getTestConfig');
 
 		// Create a mock output channel object
 		mockOutputChannel = {
@@ -235,14 +205,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 				}
 			);
 
-			// Gather results
-			// let resultingExtConfig = getTestConfig();
-			// let ExtConfigKey = resultingExtConfig?.ExtConfigKey!;
-			// let ExtConfigDesc = resultingExtConfig?.ExtConfigDesc!;
-
-			// Verify arrays are empty (only built-in keywords)
-			// assert.strictEqual(ExtConfigKey.length, 0);
-			// assert.strictEqual(ExtConfigDesc.length, 0);
 		} catch (error) {
 			console.error('Test failed:', error);
 			throw error;
@@ -255,19 +217,12 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 		console.log('Beginning of test(\'User-defined config path\'): Is extension active:', extension?.isActive);
 		assert.ok(extension.isActive, 'Extension should be active');
 		
-		// const thisConfigManager = extension.exports.configManager;
 		console.log("Extension exports: ", extension.exports);
 		const thisConfigManager = extension.exports.configManager;
 		assert.ok(thisConfigManager, 'configManager should be exported');
 		console.log('thisConfigManager instance ID:', thisConfigManager);
 		console.log('thisConfigManager constructor:', thisConfigManager.constructor.name);
 
-		// Log the state after rewiring but before the config reload
-		// console.log('Arrays after rewiring:', {
-		// 	ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
-		// 	ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
-		// });
-	    
 	    // Log the actual module instance
 	    console.log('acpihelper module:', acpihelper);
 
@@ -289,9 +244,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 			configManager.constructor === thisConfigManager.constructor);
 		// assert.strictEqual(configManager, thisConfigManager, 'Should be the same ConfigManager instance');
 		assert.notStrictEqual(configManager, thisConfigManager, 'These are NOT the same ConfigManager instance');
-		// Get the current state using the public getters
-		// let configKey = configManager.configKey;
-		// let configDesc = configManager.configDesc;
 		console.log('Before user-defined config reload: configKey = ', configManager.configKey);
 		console.log('Before user-defined config reload: configDesc = ', configManager.configDesc);
 
@@ -349,12 +301,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 			appendLineCalls: mockOutputChannel.appendLine.getCalls().map(call => call.args)
 		});
 
-		// Log the arrays state after settings reload 
-		// console.log('Arrays after config load:', {
-			// ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
-			// ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
-		// });
-		// configManager = acpihelper.__get__('configManager');
 		// Get the instance after config reload
 		const sameConfigManager = acpihelper.configManager;
 		console.log('Second configManager instance ID:', sameConfigManager);
@@ -366,8 +312,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 			configManager.constructor === sameConfigManager.constructor);
 		assert.strictEqual(configManager, sameConfigManager, 'Should be the same ConfigManager instance');
 
-		// configKey = sameConfigManager.configKey;
-		// configDesc = sameConfigManager.configDesc;
 		console.log('thisConfigManager Arrays after config load:', {
 			configKey: thisConfigManager.configKey,
 			configDesc: thisConfigManager.configDesc
@@ -390,9 +334,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 		assert.strictEqual(thisConfigManager.configDesc.length, 6);
 		assert.strictEqual(thisConfigManager.configKey[0], 'CUST');
 		assert.strictEqual(thisConfigManager.configDesc[0], 'CUSTOM Keyword Test');
-        // assert.strictEqual(ExtConfigDesc.length, 6);
-        // assert.strictEqual(ExtConfigKey[0], 'CUST');
-		// assert.strictEqual(ExtConfigDesc[0], 'CUSTOM Keyword Test');
 		
 		// Verify that test arrays contain the entire expected values
 		// TODO
@@ -425,12 +366,7 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
         // assert.ok(testOutput.some(line => line.includes('Extra keywords defined by this extension')));
 
 		// Gather results
-		// let resultingExtConfig = getTestConfig();
-		// let ExtConfigKey = resultingExtConfig?.ExtConfigKey!;
-		// let ExtConfigDesc = resultingExtConfig?.ExtConfigDesc!;
-
 		// Verify arrays contain default config data
-        // assert.ok(ExtConfigKey.length > 0);
-        // assert.ok(ExtConfigDesc.length > 0);
+		// TODO
     });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,436 @@
 import * as assert from 'assert';
-
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
+import * as fs from 'fs';
+import * as path from 'path';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import { ConfigManager } from '../../lib/configmanager';
+import rewire = require("rewire");
+let acpihelper = rewire("../../extension");
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+// const getTestConfig = acpihelper.getTestConfig;
+// if (!getTestConfig) {
+//     throw new Error('Test config not available');
+// }
+let mockOutputChannel: sinon.SinonStubbedInstance<vscode.OutputChannel>;
+let mockLogOutputChannel: sinon.SinonStubbedInstance<vscode.LogOutputChannel>;
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+// const { ExtConfigKey, ExtConfigDesc } = config;
+suite('Extension Test Suite', function (this: Mocha.Suite) {
+	// TODO: Remove Debug timeout
+	this.timeout(30000);
+
+    // let outputChannel: vscode.OutputChannel;
+	let testOutput: string[] = [];
+	let sandbox: sinon.SinonSandbox;
+	// let configSpy: sinon.SinonSpy;
+	
+	let extensionConfigManager: ConfigManager;
+	// let ExtConfigKey: string[] = ['FOO'];
+	// let ExtConfigDesc: string[] = ['Will it Foo?'];
+
+	suiteSetup(() => {
+		console.log('Setting up test suite...');
+		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
+		console.log('Before rewire: Is extension active:', extension?.isActive);
+		// extensionConfigManager = extension?.exports.__get__('configManager');
+
+		// Log the initial state of the arrays in the extension
+		// console.log('Initial extension arrays:', {
+		// 	ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
+		// 	ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
+		// });
+		// let configManager = acpihelper.__get__('configManager');
+		let configManager = acpihelper.configManager;
+		console.log('Initial extension arrays:', {
+			configKey: configManager.configKey,
+			configDesc: configManager.configDesc,
+			// "extensionConfigManager.configKey": extensionConfigManager.configKey,
+			// "extensionConfigManager.configDesc": extensionConfigManager.configDesc
+		});
+
+		// Rewire the global external config arrays with our own
+		// acpihelper.__set__({
+			// ExtConfigKey: ExtConfigKey,
+			// ExtConfigDesc: ExtConfigDesc
+		// });
+
+		// Log the state after rewiring
+		// console.log('Arrays after rewiring:', {
+		// 	ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
+		// 	ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
+		// });
+		// console.log('After rewire: Is extension active:', extension?.isActive);
+
+		sandbox = sinon.createSandbox();
+
+		// configSpy = sandbox.spy(acpihelper, 'getTestConfig');
+
+		// Create a mock output channel object
+		mockOutputChannel = {
+			append: sandbox.stub(),
+			appendLine: sandbox.stub(),
+			clear: sandbox.stub(),
+			dispose: sandbox.stub(),
+			hide: sandbox.stub(),
+			show: sandbox.stub()
+		} as sinon.SinonStubbedInstance<vscode.OutputChannel>;
+
+		mockLogOutputChannel = {
+			append: sandbox.stub(),
+			appendLine: sandbox.stub(),
+			clear: sandbox.stub(),
+			dispose: sandbox.stub(),
+			hide: sandbox.stub(),
+			show: sandbox.stub(),
+    		// Add LogOutputChannel properties
+    		logLevel: vscode.LogLevel.Info,
+    		onDidChangeLogLevel: sandbox.stub(),
+    		trace: sandbox.stub(),
+    		debug: sandbox.stub(),
+    		info: sandbox.stub(),
+    		warn: sandbox.stub(),
+    		error: sandbox.stub()
+		} as sinon.SinonStubbedInstance<vscode.LogOutputChannel>;
+
+		// Stub the createOutputChannel method to return our mocks
+		(sandbox.stub(vscode.window, 'createOutputChannel') as unknown as sinon.SinonStub).callsFake((name: string, options?: { log: boolean }) => {
+			if (options?.log) {
+				return mockLogOutputChannel;
+			}
+			return mockOutputChannel;
+		});
+
+		// Manually stub the 'show' method to handle its overloaded nature
+
+        // This allows you to test both signatures
+        //sandbox.stub(mockOutputChannel, 'show').callsFake((column?: vscode.ViewColumn | boolean, preserveFocus?: boolean) => {
+        //    // Handle different call signatures based on arguments
+        //    if (typeof column === 'boolean') {
+        //        // Called with show(preserveFocus: boolean)
+        //        console.log('Mock show called with preserveFocus:', column);
+        //    } else if (column !== undefined) {
+        //        // Called with show(column: ViewColumn, preserveFocus?: boolean)
+        //        console.log('Mock show called with column:', column, 'preserveFocus:', preserveFocus);
+        //    } else {
+        //        // Called with show()
+        //        console.log('Mock show called without arguments');
+        //    }
+        //    // You can add assertions here or store call data for later assertions
+        //});
+
+		console.log('After mocking - createOutputChannel identity:', vscode.window.createOutputChannel.prototype);
+		console.log('End of suiteSetup(): Is extension active:', extension?.isActive);
+    });
+
+	suiteTeardown(() => {
+        console.log('Tearing down test suite...');
+		mockOutputChannel.dispose();
+		mockLogOutputChannel.dispose();
+		sandbox.restore();
 	});
+
+	setup(function setupHook() {
+        // Reset the outputChannel mocks before each test
+		// mockOutputChannel.appendLine.resetHistory();
+		// mockLogOutputChannel.appendLine.resetHistory();
+        testOutput = [];
+    });
+
+    teardown(() => {
+		// Clean up after each test
+		// mockOutputChannel.appendLine.resetHistory();
+		// mockLogOutputChannel.appendLine.resetHistory();
+    });
+
+	test('Extension is loaded', async () => {
+		// const allExtensions = vscode.extensions.all;
+		// console.log('All loaded extensions:', allExtensions.map(ext => ({
+		// 	id: ext.id,
+		// 	isActive: ext.isActive
+		// })));
+
+
+		// Activate the extension
+		// await extension?.activate();
+		// Create a temporary EASL file to trigger activation
+		const tempFile = await vscode.workspace.openTextDocument({
+			content: '// Test EASL file',
+			language: 'EASL'
+		});
+		await vscode.window.showTextDocument(tempFile);
+
+		// Add a small delay to see if the extension is activated
+		// await new Promise(resolve => setTimeout(resolve, 1000));
+
+		// Wait for the extension to be activated
+		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
+    	let attempts = 0;
+    	const maxAttempts = 20;
+    	while (!extension?.isActive && attempts < maxAttempts) {
+    	    await new Promise(resolve => setTimeout(resolve, 100));
+    	    attempts++;
+    	}
+
+		// console.log('Extension:', extension);
+		// console.log('Extension ID:', extension?.id);
+		// console.log('Extension package:', extension?.packageJSON);
+		// console.log('Extension active:', extension?.isActive);
+
+        const commands = await vscode.commands.getCommands();
+		// console.log('Available commands:', commands.find((str, idx) => { str.includes('acpihelper.reloadConfig') ? true : false; }));
+		// console.log('Available commands:', commands);
+		// Activate the extension by executing one of its commands
+		await vscode.commands.executeCommand('acpihelper.Help');
+		console.log('acpihelper commands:', commands.filter(name => name.startsWith("acpi")));
+		assert.ok(commands.includes('acpihelper.reloadConfig'), 'Extension reloadConfig command should be available');
+		assert.ok(commands.includes('acpihelper.Help'), 'Extension HelpInfo command should be available');
+	});
+
+	test('Config path explicitly disabled', async () => {
+		console.log('Running test: Config path explicitly disabled');
+		try {
+			// TODO: Remove this
+			// Add debug logging for mock state
+			// console.log('Mock state before reload:', {
+			// 	appendLineCalled: mockOutputChannel.appendLine.called,
+			// 	appendLineCalls: mockOutputChannel.appendLine.getCalls().map(call => call.args)
+			// });
+
+			// Set config to disabled state
+			await vscode.workspace.getConfiguration('acpihelper').update('configPath', '', true);
+			await vscode.workspace.getConfiguration('acpihelper').update('includeUserConfig', true, true);
+
+			// Clear previous output
+			testOutput = [];
+			// console.log('Initial testOutput:', testOutput); // TODO: Remove Debug log
+
+			// Trigger config reload
+			// await vscode.commands.executeCommand('workbench.action.reloadWindow');
+			// outputChannel.show();
+			// await vscode.commands.executeCommand('workbench.action.openView', 'Output');
+			await vscode.commands.executeCommand('workbench.panel.output.focus');
+			await vscode.commands.executeCommand('acpihelper.reloadConfig');
+
+			// Add a small delay to allow output to be captured
+			// await new Promise(resolve => setTimeout(resolve, 30000));
+			await new Promise(resolve => setTimeout(resolve, 1000));
+
+			// Add debug logging for mock state after reload
+			// console.log('Mock state after reload:', {
+			// 	appendLineCalled: mockOutputChannel.appendLine.called,
+			// 	appendLineCalls: mockOutputChannel.appendLine.getCalls().map(call => call.args)
+			// });
+
+			console.log('After reload, testOutput:', testOutput); // TODO: Remove Debug log
+
+			// Verify output messages
+			assert.ok(mockOutputChannel.appendLine.called, 'appendLine should have been called');
+			['Config path disabled.',
+			'Only standard keywords in ACPI specification will be shown.'].forEach(
+				expectedMessage => {
+					assert.ok(mockOutputChannel.appendLine.calledWith(expectedMessage), 
+						`Expected '${expectedMessage}' message, got calls: ${JSON.stringify(mockOutputChannel.appendLine.getCalls().map(call => call.args))}`);
+				}
+			);
+
+			// Gather results
+			// let resultingExtConfig = getTestConfig();
+			// let ExtConfigKey = resultingExtConfig?.ExtConfigKey!;
+			// let ExtConfigDesc = resultingExtConfig?.ExtConfigDesc!;
+
+			// Verify arrays are empty (only built-in keywords)
+			// assert.strictEqual(ExtConfigKey.length, 0);
+			// assert.strictEqual(ExtConfigDesc.length, 0);
+		} catch (error) {
+			console.error('Test failed:', error);
+			throw error;
+		}
+    });
+
+	test('User-defined config path', async () => {
+		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
+		assert.ok(extension, 'Extension should be found');
+		console.log('Beginning of test(\'User-defined config path\'): Is extension active:', extension?.isActive);
+		assert.ok(extension.isActive, 'Extension should be active');
+		
+		// const thisConfigManager = extension.exports.configManager;
+		console.log("Extension exports: ", extension.exports);
+		const thisConfigManager = extension.exports.configManager;
+		assert.ok(thisConfigManager, 'configManager should be exported');
+		console.log('thisConfigManager instance ID:', thisConfigManager);
+		console.log('thisConfigManager constructor:', thisConfigManager.constructor.name);
+
+		// Log the state after rewiring but before the config reload
+		// console.log('Arrays after rewiring:', {
+		// 	ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
+		// 	ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
+		// });
+	    
+	    // Log the actual module instance
+	    console.log('acpihelper module:', acpihelper);
+
+		// Log the actual instance we're getting
+		console.log('acpihelper.configManager instance ID:', acpihelper.configManager);
+		console.log('acpihelper.configManager constructor:', acpihelper.configManager.constructor.name);
+
+		// Log the require cache for our extension
+		console.log('Require cache keys:', Object.keys(require.cache));
+		console.log('Extension module in cache:', require.cache[require.resolve('../../extension')]);
+		
+		// Get the ConfigManager instance from the extension (before config reload)
+		// let configManager = acpihelper.__get__('configManager');
+		const configManager = acpihelper.configManager;
+		console.log('First configManager instance ID:', configManager);
+		console.log('Extension exports thisConfigManager instance ID:', thisConfigManager);
+		console.log('Are instances the same?', configManager === thisConfigManager);
+		console.log('Are instances from same constructor?', 
+			configManager.constructor === thisConfigManager.constructor);
+		// assert.strictEqual(configManager, thisConfigManager, 'Should be the same ConfigManager instance');
+		assert.notStrictEqual(configManager, thisConfigManager, 'These are NOT the same ConfigManager instance');
+		// Get the current state using the public getters
+		// let configKey = configManager.configKey;
+		// let configDesc = configManager.configDesc;
+		console.log('Before user-defined config reload: configKey = ', configManager.configKey);
+		console.log('Before user-defined config reload: configDesc = ', configManager.configDesc);
+
+		// Now we can use this instance for our tests
+		console.log('Before config reload:', {
+			"configManager.configKey": configManager.configKey,
+			"configManager.configDesc": configManager.configDesc,
+			"thisConfigManager.configKey": thisConfigManager.configKey,
+			"thisConfigManager.configDesc": thisConfigManager.configDesc
+		});
+
+		// Get path to test fixture
+        const testConfigPath = path.join(__dirname, '../../test/fixtures/AcpiCfg-test.json');
+		const expectedConfig = JSON.parse(fs.readFileSync(testConfigPath).toString());
+
+		// TODO: Remove this
+		// Add debug logging for mock state before settings reload
+		console.log('Mock state before user-defined config reload:', {
+			appendLineCalled: mockOutputChannel.appendLine.called,
+			appendLineCalls: mockOutputChannel.appendLine.getCalls().map(call => call.args)
+		});
+
+    	// Create a promise that resolves when the "Finished loading config!" message is logged
+		const configLoadedPromise = new Promise<void>((resolve) => {
+			const checkForMessage = () => {
+				// Check for only the most recent calls
+				const recentCalls = mockOutputChannel.appendLine.getCalls().slice(-3);
+				if (recentCalls.some(call => call.args[0] === 'Finished loading config!')) {
+				// if (mockOutputChannel.appendLine.calledWith('Finished loading config!')) {
+					resolve();
+				} else {
+					setTimeout(checkForMessage, 100);
+				}
+			};
+			checkForMessage();
+		});
+
+        // Set config to use test fixture
+        await vscode.workspace.getConfiguration('acpihelper').update('configPath', testConfigPath, true);
+        await vscode.workspace.getConfiguration('acpihelper').update('includeUserConfig', true, true);
+
+        // Clear previous output
+        testOutput = [];
+
+        // Trigger config reload
+		// await vscode.commands.executeCommand('workbench.action.reloadWindow');
+		// await vscode.commands.executeCommand('acpihelper.reloadConfig');
+
+		// Wait for the config to finish loading, and for result arrays to be populated 
+		await configLoadedPromise;
+
+		// Add debug logging for mock state after settings reload
+		console.log('Mock state after user-defined config reload:', {
+			appendLineCalled: mockOutputChannel.appendLine.called,
+			appendLineCalls: mockOutputChannel.appendLine.getCalls().map(call => call.args)
+		});
+
+		// Log the arrays state after settings reload 
+		// console.log('Arrays after config load:', {
+			// ExtConfigKey: acpihelper.__get__('ExtConfigKey'),
+			// ExtConfigDesc: acpihelper.__get__('ExtConfigDesc')
+		// });
+		// configManager = acpihelper.__get__('configManager');
+		// Get the instance after config reload
+		const sameConfigManager = acpihelper.configManager;
+		console.log('Second configManager instance ID:', sameConfigManager);
+		// console.log('After user-defined config reload: ConfigManager instance:', sameConfigManager);
+		// Verify they are the same instance
+		// Log the actual object references
+		console.log('Are instances the same?', configManager === sameConfigManager);
+		console.log('Are instances from same constructor?', 
+			configManager.constructor === sameConfigManager.constructor);
+		assert.strictEqual(configManager, sameConfigManager, 'Should be the same ConfigManager instance');
+
+		// configKey = sameConfigManager.configKey;
+		// configDesc = sameConfigManager.configDesc;
+		console.log('thisConfigManager Arrays after config load:', {
+			configKey: thisConfigManager.configKey,
+			configDesc: thisConfigManager.configDesc
+		});
+
+		// Verify output messages
+		[sinon.match((arg: string) => arg.startsWith('User-defined config path')),
+			'Extra user-defined keywords and those in the ACPI specification will be shown.'].forEach(
+			expectedMessage => {
+				assert.ok(mockOutputChannel.appendLine.calledWith(expectedMessage), 
+					`Expected '${expectedMessage}' message, got calls: ${JSON.stringify(mockOutputChannel.appendLine.getCalls().map(call => call.args))}`);
+			}
+		);
+
+		// Add a small delay to see if the extension is activated
+		console.log('Waiting 3 seconds before checking arrays...');
+		await new Promise(resolve => setTimeout(resolve, 3000));
+
+		// Verify arrays contain unique test fixture data
+		assert.strictEqual(thisConfigManager.configDesc.length, 6);
+		assert.strictEqual(thisConfigManager.configKey[0], 'CUST');
+		assert.strictEqual(thisConfigManager.configDesc[0], 'CUSTOM Keyword Test');
+        // assert.strictEqual(ExtConfigDesc.length, 6);
+        // assert.strictEqual(ExtConfigKey[0], 'CUST');
+		// assert.strictEqual(ExtConfigDesc[0], 'CUSTOM Keyword Test');
+		
+		// Verify that test arrays contain the entire expected values
+		// TODO
+
+    });
+
+    test('Default config path', async () => {
+        // Set config to use default path
+        await vscode.workspace.getConfiguration('acpihelper').update('configPath', '', true);
+        await vscode.workspace.getConfiguration('acpihelper').update('includeUserConfig', false, true);
+
+        // Clear previous output
+        testOutput = [];
+
+        // Trigger config reload
+		// await vscode.commands.executeCommand('workbench.action.reloadWindow');
+		await vscode.commands.executeCommand('acpihelper.reloadConfig');
+
+		// Verify output messages
+		[sinon.match((arg: string) => arg.startsWith('Default extension-provided config path')),
+			'Extra keywords defined by this extension and those in the ACPI specification will be shown.'].forEach(
+			expectedMessage => {
+				assert.ok(mockOutputChannel.appendLine.calledWith(expectedMessage), 
+					`Expected '${expectedMessage}' message, got calls: ${JSON.stringify(mockOutputChannel.appendLine.getCalls().map(call => call.args))}`);
+			}
+		);
+		
+		// TODO: Remove old broken assertions
+        // assert.ok(testOutput.some(line => line.includes('Default extension-provided config path')));
+        // assert.ok(testOutput.some(line => line.includes('Extra keywords defined by this extension')));
+
+		// Gather results
+		// let resultingExtConfig = getTestConfig();
+		// let ExtConfigKey = resultingExtConfig?.ExtConfigKey!;
+		// let ExtConfigDesc = resultingExtConfig?.ExtConfigDesc!;
+
+		// Verify arrays contain default config data
+        // assert.ok(ExtConfigKey.length > 0);
+        // assert.ok(ExtConfigDesc.length > 0);
+    });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -101,8 +101,8 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 
     teardown(() => {
 		// Clean up after each test
-		// mockOutputChannel.appendLine.resetHistory();
-		// mockLogOutputChannel.appendLine.resetHistory();
+		mockOutputChannel.appendLine.resetHistory();
+		mockLogOutputChannel.appendLine.resetHistory();
     });
 
 	// Tests Activation of the extension via ASL file

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -20,20 +20,11 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 	let testOutput: string[] = [];
 	let sandbox: sinon.SinonSandbox;
 	let configManager: ConfigManager;
+	const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
 
 	suiteSetup(() => {
 		console.log('Setting up test suite...');
-		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
 		console.log('Before rewire: Is extension active:', extension?.isActive);
-		configManager = extension?.exports.__get__('configManager');
-
-		// Log the initial state of the arrays in the extension
-		console.log('Initial extension arrays:', {
-			configKey: configManager.configKey,
-			configDesc: configManager.configDesc,
-			// "extensionConfigManager.configKey": extensionConfigManager.configKey,
-			// "extensionConfigManager.configDesc": extensionConfigManager.configDesc
-		});
 
 		sandbox = sinon.createSandbox();
 
@@ -114,6 +105,10 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 		// mockLogOutputChannel.appendLine.resetHistory();
     });
 
+	// Tests Activation of the extension via ASL file
+	// Also retreives the extension instance for use in subsequent tests
+	//
+	// Side Effect: suite-global extension is set to the extension instance
 	test('Extension is loaded', async () => {
 		// const allExtensions = vscode.extensions.all;
 		// console.log('All loaded extensions:', allExtensions.map(ext => ({
@@ -135,7 +130,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 		// await new Promise(resolve => setTimeout(resolve, 1000));
 
 		// Wait for the extension to be activated
-		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
     	let attempts = 0;
     	const maxAttempts = 20;
     	while (!extension?.isActive && attempts < maxAttempts) {
@@ -147,6 +141,16 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 		// console.log('Extension ID:', extension?.id);
 		// console.log('Extension package:', extension?.packageJSON);
 		// console.log('Extension active:', extension?.isActive);
+
+		configManager = extension?.exports.configManager;
+
+		// Log the initial state of the arrays in the extension
+		console.log('Initial extension arrays:', {
+			configKey: configManager.configKey,
+			configDesc: configManager.configDesc,
+			// "extensionConfigManager.configKey": extensionConfigManager.configKey,
+			// "extensionConfigManager.configDesc": extensionConfigManager.configDesc
+		});
 
         const commands = await vscode.commands.getCommands();
 		// console.log('Available commands:', commands.find((str, idx) => { str.includes('acpihelper.reloadConfig') ? true : false; }));
@@ -212,7 +216,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
     });
 
 	test('User-defined config path', async () => {
-		const extension = vscode.extensions.getExtension('WilliamWu-HJ.acpihelper');
 		assert.ok(extension, 'Extension should be found');
 		console.log('Beginning of test(\'User-defined config path\'): Is extension active:', extension?.isActive);
 		assert.ok(extension.isActive, 'Extension should be active');
@@ -272,7 +275,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 				// Check for only the most recent calls
 				const recentCalls = mockOutputChannel.appendLine.getCalls().slice(-3);
 				if (recentCalls.some(call => call.args[0] === 'Finished loading config!')) {
-				// if (mockOutputChannel.appendLine.calledWith('Finished loading config!')) {
 					resolve();
 				} else {
 					setTimeout(checkForMessage, 100);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -14,7 +14,7 @@ let mockLogOutputChannel: sinon.SinonStubbedInstance<vscode.LogOutputChannel>;
 
 suite('Extension Test Suite', function (this: Mocha.Suite) {
 	// TODO: Remove Debug timeout
-	this.timeout(30000);
+	// this.timeout(30000);
 
     // let outputChannel: vscode.OutputChannel;
 	let testOutput: string[] = [];
@@ -189,7 +189,7 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 
 			// Add a small delay to allow output to be captured
 			// await new Promise(resolve => setTimeout(resolve, 30000));
-			await new Promise(resolve => setTimeout(resolve, 1000));
+			// await new Promise(resolve => setTimeout(resolve, 1000));
 
 			// Add debug logging for mock state after reload
 			// console.log('Mock state after reload:', {
@@ -328,9 +328,6 @@ suite('Extension Test Suite', function (this: Mocha.Suite) {
 			}
 		);
 
-		// Add a small delay to see if the extension is activated
-		console.log('Waiting 3 seconds before checking arrays...');
-		await new Promise(resolve => setTimeout(resolve, 3000));
 
 		// Verify arrays contain unique test fixture data
 		assert.strictEqual(thisConfigManager.configDesc.length, 6);


### PR DESCRIPTION
- **ci: add test fixture ApiCfg-test.json**
- **ci: Copy test fixtures after tsc compile & before test/pretest**
- **ci: Add test utils: rewire, sinon**
- **ci: Bump targeted vscode engine to ^1.75.0**
- **ci: npm install update dependencies**
- **ci: Add logging & env vars to @vscode/test-electron's runTests()**
- **ci: Comment out VSCODE_* env vars for now**
- **Add acpihelper.reloadConfig command: Reloads user-provided external .json config**
- **Add ConfigManager class to store & manage user-provided config**
- **Refactor to use ConfigManager class & export for testing**
- **ci: Add integration tests**
- **Cleanup old global array implementation & debug (ExtConfigKey, ExtConfigDesc)**
- **ci: Cleanup broken attempts to test global arrays (ExtConfigKey, ExtConfigDesc)**
- **ci: Grab configManager instance from extension.exports after activation**
- **ci: Remove debugging delays & timeout**
- **ci: Reinstate mock OutputChannel clear between tests**
