### PR TITLE
fix eslint style warnings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ function handleConfigChange(event: vscode.ConfigurationChangeEvent, context: vsc
     }
 }
 
-function getPreDefineObjIndex(STxt: string) :string {
+function getPreDefineObjIndex(sTxt: string) :string {
     const PRE_DEFINE_NAME: string[] = [
         "_ACx", "_ADR", "_AEI", "_ALC", 
         "_ALI", "_ALN", "_ALP", "_ALR", 
@@ -1002,47 +1002,47 @@ function getPreDefineObjIndex(STxt: string) :string {
         "Compaq 14400 modem (TBD)", 
         "Compaq 2400/9600 modem (TBD)"
     ];
-    for (let IndexVal =0 ; IndexVal < PRE_DEFINE_NAME.length; IndexVal ++)
+    for (let indexVal =0 ; indexVal < PRE_DEFINE_NAME.length; indexVal ++)
     {
-        if (STxt.toUpperCase() === PRE_DEFINE_NAME[IndexVal].toUpperCase())
+        if (sTxt.toUpperCase() === PRE_DEFINE_NAME[indexVal].toUpperCase())
         {
-            if (PRE_DEF_NAME_HELP_STR.length >= IndexVal)
+            if (PRE_DEF_NAME_HELP_STR.length >= indexVal)
             {
-                return PRE_DEF_NAME_HELP_STR[IndexVal];
+                return PRE_DEF_NAME_HELP_STR[indexVal];
             }
         }
     }
 
-    let UpStrNew = STxt.toUpperCase();
-    if ((UpStrNew.length === 7) && (UpStrNew.indexOf("PNP")>=0)) // PNP
+    let upStrNew = sTxt.toUpperCase();
+    if ((upStrNew.length === 7) && (upStrNew.indexOf("PNP")>=0)) // PNP
     {
-        if (UpStrNew.indexOf("PNP0")>=0){
+        if (upStrNew.indexOf("PNP0")>=0){
             return "System Device. Note: only generic info was found based on PNP Spec.";
         }
-        if (UpStrNew.indexOf("PNP8")>=0){
+        if (upStrNew.indexOf("PNP8")>=0){
             return "Network adapters.";
         }
-        if (UpStrNew.indexOf("PNPA")>=0){
+        if (upStrNew.indexOf("PNPA")>=0){
             return "Small computer system interface (SCSI), proprietary CD adapters. Note: only generic info was found based on PNP Spec.";
         }
-        if (UpStrNew.indexOf("PNPB")>=0){
+        if (upStrNew.indexOf("PNPB")>=0){
             return "Sound, video capture, multimedia. Note: only generic info was found based on PNP Spec.";
         }
-        if (UpStrNew.indexOf("PNPC")>=0){
+        if (upStrNew.indexOf("PNPC")>=0){
             return "Modems. Note: only generic info was found based on PNP Spec.";
         }
-        if (UpStrNew.indexOf("PNPD")>=0){
+        if (upStrNew.indexOf("PNPD")>=0){
             return "Modems. Note: only generic info was found based on PNP Spec.";
         }
     }
  
-    for (let IndexVal =0 ; IndexVal < configManager.configKey.length; IndexVal ++)
+    for (let indexVal =0 ; indexVal < configManager.configKey.length; indexVal ++)
     {
-        if (STxt.toUpperCase() === configManager.configKey[IndexVal].toUpperCase())
+        if (sTxt.toUpperCase() === configManager.configKey[indexVal].toUpperCase())
         {
-            if (configManager.configDesc.length >= IndexVal)
+            if (configManager.configDesc.length >= indexVal)
             {
-                return configManager.configDesc[IndexVal];
+                return configManager.configDesc[indexVal];
             }
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
         provideHover(document, position, token) {
             const range = document.getWordRangeAtPosition(position);
             const word = document.getText(range);
-            let strTxt: string = GetPreDefineObjIndex(word);
+            let strTxt: string = getPreDefineObjIndex(word);
             if (strTxt !== "")
             {
                 return new vscode.Hover(strTxt);
@@ -127,7 +127,7 @@ function handleConfigChange(event: vscode.ConfigurationChangeEvent, context: vsc
     }
 }
 
-function GetPreDefineObjIndex(STxt: string) :string {
+function getPreDefineObjIndex(STxt: string) :string {
     const PRE_DEFINE_NAME: string[] = [
         "_ACx", "_ADR", "_AEI", "_ALC", 
         "_ALI", "_ALN", "_ALP", "_ALR", 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
             const range = document.getWordRangeAtPosition(position);
             const word = document.getText(range);
             let strTxt: string = GetPreDefineObjIndex(word);
-            if (strTxt != "")
+            if (strTxt !== "")
             {
                 return new vscode.Hover(strTxt);
             }
@@ -87,7 +87,7 @@ function loadConfig(context: vscode.ExtensionContext) {
         useConfig = false;
         output.appendLine('Config path disabled.');
         output.appendLine('Only standard keywords in ACPI specification will be shown.');
-    } else if (cfgPath != "" && includeUserConfig) {
+    } else if (cfgPath !== "" && includeUserConfig) {
     // Use user-defined config path
         useConfig = true;
         output.appendLine('User-defined config path: ' + cfgPath);
@@ -1004,7 +1004,7 @@ function GetPreDefineObjIndex(STxt: string) :string {
     ];
     for (let IndexVal =0 ; IndexVal < PreDefineName.length; IndexVal ++)
     {
-        if (STxt.toUpperCase() == PreDefineName[IndexVal].toUpperCase())
+        if (STxt.toUpperCase() === PreDefineName[IndexVal].toUpperCase())
         {
             if (PreDefNameHelpStr.length >= IndexVal)
             {
@@ -1014,7 +1014,7 @@ function GetPreDefineObjIndex(STxt: string) :string {
     }
 
     let UpStrNew = STxt.toUpperCase();
-    if ((UpStrNew.length == 7) && (UpStrNew.indexOf("PNP")>=0)) // PNP
+    if ((UpStrNew.length === 7) && (UpStrNew.indexOf("PNP")>=0)) // PNP
     {
         if (UpStrNew.indexOf("PNP0")>=0){
             return "System Device. Note: only generic info was found based on PNP Spec.";
@@ -1038,7 +1038,7 @@ function GetPreDefineObjIndex(STxt: string) :string {
  
     for (let IndexVal =0 ; IndexVal < configManager.configKey.length; IndexVal ++)
     {
-        if (STxt.toUpperCase() == configManager.configKey[IndexVal].toUpperCase())
+        if (STxt.toUpperCase() === configManager.configKey[IndexVal].toUpperCase())
         {
             if (configManager.configDesc.length >= IndexVal)
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,7 +128,7 @@ function handleConfigChange(event: vscode.ConfigurationChangeEvent, context: vsc
 }
 
 function GetPreDefineObjIndex(STxt: string) :string {
-    let PreDefineName: string[] = [
+    const PRE_DEFINE_NAME: string[] = [
         "_ACx", "_ADR", "_AEI", "_ALC", 
         "_ALI", "_ALN", "_ALP", "_ALR", 
         "_ALT", "_ALx", "_ART", "_ASI", 
@@ -375,7 +375,7 @@ function GetPreDefineObjIndex(STxt: string) :string {
         "PNPC001"
     ];
 
-    let PreDefNameHelpStr: string[] = [
+    const PRE_DEF_NAME_HELP_STR: string[] = [
         "Active Cooling – returns the active cooling policy threshold values.", 
         "Address: (1) returns the address of a device on its parent bus. (2) returns a unique ID for the display output device. (3) resource descriptor field.", 
         "Designates those GPIO interrupts that shall be handled by OSPM as ACPI events.", 
@@ -1002,13 +1002,13 @@ function GetPreDefineObjIndex(STxt: string) :string {
         "Compaq 14400 modem (TBD)", 
         "Compaq 2400/9600 modem (TBD)"
     ];
-    for (let IndexVal =0 ; IndexVal < PreDefineName.length; IndexVal ++)
+    for (let IndexVal =0 ; IndexVal < PRE_DEFINE_NAME.length; IndexVal ++)
     {
-        if (STxt.toUpperCase() === PreDefineName[IndexVal].toUpperCase())
+        if (STxt.toUpperCase() === PRE_DEFINE_NAME[IndexVal].toUpperCase())
         {
-            if (PreDefNameHelpStr.length >= IndexVal)
+            if (PRE_DEF_NAME_HELP_STR.length >= IndexVal)
             {
-                return PreDefNameHelpStr[IndexVal];
+                return PRE_DEF_NAME_HELP_STR[IndexVal];
             }
         }
     }


### PR DESCRIPTION
- **src/extension.ts: Fix eqeqeq eslint warnings**
- **Change predefined keyword/desc arrays to constants & follow const naming convention**
- **src/extension.ts: Change GetPreDefineObjIndex() to camelCase (@typescript-eslint/naming-convention)**
- **src/extension.ts: Fix remaining var eslint camelCase warnings (@typescript-eslint/naming-convention)**
